### PR TITLE
Support props on components injected via spread operator

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,56 @@
+// TODO: there should be validation that the spreadObjectString is actually an object.
+// check beginning and end chars to validate?
+function getPropsFromObjectString (spreadObjectString) {
+  function normalizeProp (propName) {
+    return propName.replaceAll("'", "")
+  }
+
+  const props = []
+  let currentProp = ""
+  let keyWithValue = false;
+  [...spreadObjectString].forEach((c) => {
+    if (c === ",") {
+      props.push(normalizeProp(currentProp))
+      currentProp = ""
+      keyWithValue = false
+      return
+    } else if (
+      c === "{" ||
+      c === "}" ||
+      c === " " ||
+      c === "\n" ||
+      keyWithValue
+    ) {
+      return
+    } else if (c === ":") {
+      keyWithValue = true
+      return
+    }
+
+    currentProp += c
+  })
+
+  return props
+}
+
+function getCamelCasedString (str, charDelimiter) {
+  let newPropName = str
+  while (newPropName.includes(charDelimiter)) {
+    const indexOfDash = newPropName.indexOf(charDelimiter)
+    const charAfterDash = newPropName.charAt(indexOfDash + 1)
+
+    newPropName = `${newPropName.substring(
+      0,
+      indexOfDash
+    )}${charAfterDash.toUpperCase()}${newPropName.substring(
+      indexOfDash + 2,
+      newPropName.length
+    )}`
+  }
+  return newPropName
+}
+
+module.exports = {
+  getPropsFromObjectString,
+  getCamelCasedString,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-react-camel-case",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "description": "ESLint rules for camelCasing React props",
   "keywords": [
     "eslint",

--- a/rules/react-camel-case.js
+++ b/rules/react-camel-case.js
@@ -25,7 +25,9 @@ module.exports = {
     function getPropName (propNode) {
       switch (propNode.type) {
         case "JSXSpreadAttribute":
-          return context.getSourceCode().getText(propNode.argument)
+          return getPropsFromSpreadObjectString(context
+            .getSourceCode()
+            .getText(propNode.argument))
         case "JSXIdentifier":
           return propNode.name
         case "JSXMemberExpression":
@@ -39,17 +41,44 @@ module.exports = {
       }
     }
 
+    function getPropsFromSpreadObjectString (spreadObjectString) {
+      const props = []
+      let currentProp = '';
+      let keyWithValue = false;
+      [...spreadObjectString].forEach((c) => {
+        console.log(c, currentProp)
+        if (c === ',') {
+          props.push(currentProp)
+          currentProp = ''
+          keyWithValue = false
+        } else if (c === '{' || c === '}' || c === ' ' || c === '\n' || keyWithValue) {
+          return
+        } else if (c === ':') {
+          keyWithValue = true
+        }
+
+        console.log('hey gurl **\n')
+        // this concat isn't working? 
+        currentProp += c
+        console.log(currentProp)
+      })
+
+      console.log(props)
+
+     return spreadObjectString
+    }
+
     function getJSXTagName (jsxNode) {
       switch (jsxNode.type) {
         case "JSXIdentifier":
-          return propNode.name
+          return jsxNode.name
         default:
           return jsxNode.name.name
       }
     }
 
     function isCustomHTMLElement (node) {
-      return getJSXTagName(node).includes("-")
+      return getJSXTagName(node)?.includes("-")
     }
 
     function getCamelCasedString (str, charDelimiter) {
@@ -72,7 +101,9 @@ module.exports = {
     return {
       JSXOpeningElement: (node) => {
         node.attributes.forEach((attr) => {
+          if (getJSXTagName(node) === "StyledButton") console.log(attr)
           const propName = getPropName(attr)
+          if (getJSXTagName(node) === "StyledButton") console.log(propName, typeof propName)
 
           const dash = "-"
           if (
@@ -95,10 +126,10 @@ module.exports = {
                   fixableCharacter: "dashes",
                 },
                 fix (fixer) {
-                  return fixer.replaceText(
+                  return fixer?.repalceText ? fixer.replaceText(
                     attr.name,
                     getCamelCasedString(propName, dash)
-                  )
+                  ) : null
                 },
               })
             }

--- a/rules/react-camel-case.js
+++ b/rules/react-camel-case.js
@@ -43,6 +43,8 @@ module.exports = {
       }
     }
 
+    // TODO: there should be validation that the spreadObjectString is actually an object.
+    // check beginning and end chars to validate?
     function getPropsFromSpreadObjectString (spreadObjectString) {
       function normalizeProp (propName) {
         return propName.replaceAll("'", "")
@@ -126,7 +128,6 @@ module.exports = {
               fixableCharacter: "dashes",
             },
             fix (fixer) {
-              // console.log(fixableNode.argument.properties)
               return fixer?.replaceText
                 ? fixer.replaceText(
                     fixableNode,
@@ -155,14 +156,21 @@ module.exports = {
         }
 
         function attributeHandler (attr) {
+          const dash = "-"
+
           if (isSpreadAttribute(attr)) {
             const props = getPropsFromSpreadObjectString(getPropContent(attr))
-            props.forEach((prop) => performErrorChecking(prop, attr, "-"))
+            props.forEach((prop) => {
+              const nodeToFix = attr.argument.properties?.find((node) => {
+                return node?.key?.value === prop
+              })?.key
+
+              performErrorChecking(prop, nodeToFix, dash)
+            })
             return
           }
 
           const propName = getPropName(attr)
-          const dash = "-"
           performErrorChecking(propName, attr.name, dash)
         }
 


### PR DESCRIPTION
Something like this does not work right now:
```<StyledButton
        type="link"
        {...{
          to,
          href,
          target,
          onClick,
          'data-cy': dataCy,
        }}
      >
```

This enables linting against props like this as well, and fixes a key `like-this` to be 'likeThis'