### PR TITLE
Catching namespaced props and style props that are strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ Case #3: string style attributes
 ## Contributing
 
 Pull requests are welcome. Please checkout the [open issues](https://github.com/fostimus/eslint-plugin-react-camel-case/issues) we have if you'd like to help out. Bugfixes and related features are also welcome.
+
+I'd like to split out the 3 cases into their own separate eslint rules, as is convention with eslint plugins. As of now, the rule `react-camel-case` will hit all 3 cases, which is what I would like in my projects, but not necessarily what other consumers would like.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-plugin-react-camel-case
+# eslint-plugin-svg-jsx
 
 Enforce camelCased props instead of dashed props.
 
@@ -67,6 +67,6 @@ Case #3: string style attributes
 
 ## Contributing
 
-Pull requests are welcome. Please checkout the [open issues](https://github.com/fostimus/eslint-plugin-react-camel-case/issues) we have if you'd like to help out. Bugfixes and related features are also welcome.
+Pull requests are welcome. Please checkout the [open issues](https://github.com/fostimus/eslint-plugin-svg-jsx/issues) we have if you'd like to help out. Bugfixes and related features are also welcome.
 
 I'd like to split out the 3 cases into their own separate eslint rules, as is convention with eslint plugins. As of now, the rule `react-camel-case` will hit all 3 cases, which is what I would like in my projects, but not necessarily what other consumers would like.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Case #2: Colons in props.
 />
 ```
 
-Case #3: string style attributes: NOT YET IMPLEMENTED
+Case #3: string style attributes
 ```js
 // invalid
 <mask

--- a/README.md
+++ b/README.md
@@ -4,12 +4,39 @@ Enforce camelCased props instead of dashed props.
 
 ## Code examples
 
+Case #1: Dashes in props. 
+
 ```js
+// invalid
+<MyComponent margin-left={30} />
+
 // valid
 <MyComponent marginLeft={30} />
 
+```
+
+Case #2: Colons in props. 
+
+```js
 // invalid
-<MyComponent margin-left={30} />
+<svg
+    width="546"
+    height="382"
+    viewBox="0 0 546 382"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+/>
+
+// valid
+<svg
+    width="546"
+    height="382"
+    viewBox="0 0 546 382"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+/>
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -39,6 +39,32 @@ Case #2: Colons in props.
 />
 ```
 
+Case #3: string style attributes: NOT YET IMPLEMENTED
+```js
+// invalid
+<mask
+    style="mask-type:alpha"
+    maskUnits="userSpaceOnUse"
+    x="408"
+    y="144"
+    width="90"
+    height="194"
+/>
+
+// valid
+<mask
+    style={{ maskType: 'alpha' }}
+    maskUnits="userSpaceOnUse"
+    x="408"
+    y="144"
+    width="90"
+    height="194"
+/>
+
+
+```
+
+
 ## Contributing
 
 Pull requests are welcome. Please checkout the [open issues](https://github.com/fostimus/eslint-plugin-react-camel-case/issues) we have if you'd like to help out. Bugfixes and related features are also welcome.

--- a/helpers.js
+++ b/helpers.js
@@ -50,7 +50,35 @@ function getCamelCasedString (str, charDelimiter) {
   return newPropName
 }
 
+function stringify (obj) {
+  let stringified = ""
+  Object.entries(obj).forEach(([key, val]) => {
+    stringified += ` ${key}: '${val}',`
+  })
+
+  // remove trailing comma, wrap in object literal. spacing is important.
+  return `{${stringified.substring(0, stringified.length - 1)} }`
+}
+
+
+// example of 1 key-value pair: "mask-type:alpha" -> { maskType: 'alpha' }
+// example of 2 key-value pairs: "mask-type:alpha;mask-repeat:no-repeat" -> { maskType: 'alpha', maskRepeat: 'no-repeat' }
+// example of 3 key-value pairs: "mask-type:alpha;mask-repeat:no-repeat;mask-position:center" -> { maskType: 'alpha', maskRepeat: 'no-repeat', maskPosition: 'center' }
+function convertStringStyleValue (value) {
+   if (!value) return value
+
+  const styleRules = value.split(";")
+  const styleObject = styleRules.reduce((acc, rule) => {
+    const [key, val] = rule.split(":")
+    const camelCasedKey = getCamelCasedString(key.trim(), "-")
+    return { ...acc, [camelCasedKey]: val.trim() }
+  }, {})
+
+  return stringify(styleObject)
+}
+
 module.exports = {
   getPropsFromObjectString,
   getCamelCasedString,
+  convertStringStyleValue,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-svg-jsx",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "ESLint rules for camelCasing React props",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-plugin-react-camel-case",
-  "version": "1.1.2",
+  "name": "eslint-plugin-svg-jsx",
+  "version": "0.0.0",
   "description": "ESLint rules for camelCasing React props",
   "keywords": [
     "eslint",
@@ -33,10 +33,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:fostimus/eslint-plugin-react-camel-case.git"
+    "url": "git@github.com:fostimus/eslint-plugin-svg-jsx.git"
   },
   "bugs": {
-    "url": "https://github.com/fostimus/eslint-plugin-react-camel-case/issues"
+    "url": "https://github.com/fostimus/eslint-plugin-svg-jsx/issues"
   },
-  "homepage": "https://github.com/fostimus/eslint-plugin-react-camel-case"
+  "homepage": "https://github.com/fostimus/eslint-plugin-svg-jsx"
 }

--- a/rules/react-camel-case.js
+++ b/rules/react-camel-case.js
@@ -45,7 +45,7 @@ module.exports = {
         case "JSXMemberExpression":
           return `${getPropContent(node.object)}.${node.property.name}`
         case "JSXAttribute":
-          if (node?.name?.namespace?.name === "xmlns" && node?.name?.name?.name === "xlink") {
+          if (node?.name?.namespace?.name && node?.name?.name?.name) {
             return `${node?.name?.namespace?.name}:${node?.name?.name?.name}`
           }      
           else {

--- a/rules/react-camel-case.js
+++ b/rules/react-camel-case.js
@@ -35,7 +35,17 @@ module.exports = {
           return node.name
         case "JSXMemberExpression":
           return `${getPropContent(node.object)}.${node.property.name}`
+        case "JSXAttribute":
+            if (node?.name?.namespace?.name === "xmlns" && node?.name?.name?.name === "xlink") {
+              console.log(node)
+            }        
+            // case "JSXNamespacedName":  JSXNamespacedName is in the node.name field under JSXAttribute
+          // console.log(node?.name?.namespace?.name, node?.name?.name?.name)
+          return node.name
         default:
+          
+          // the below is what we want, but how to catch in ^ JSXNamespacedName?
+          // console.log(node?.name?.namespace?.name, node?.name?.name?.name)
           return node.name
             ? node.name.name
             : `${context.getSourceCode().getText(node.object)}.${
@@ -68,6 +78,7 @@ module.exports = {
     return {
       JSXOpeningElement: (node) => {
         function validateAndFixProp (propName, fixableNode, charDelimiter) {
+          // console.log(propName)
           if (
             propName?.includes &&
             propName.includes(charDelimiter) &&


### PR DESCRIPTION
This catching more annoying cases of copying SVGs into React as JSX. It's documented in the readme the 2 new cases added.

I'm thinking about renaming this package now that it's not just camel casing props... Maybe eslint-plugin-svg-jsx?

Probably some ~synergy with [this eslint plugin](https://github.com/raix/eslint-plugin-react-svg). Different rules, but would be sweet to lint away all svg problems in JSX